### PR TITLE
Publish archive to GitHub Release

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -60,4 +60,4 @@ jobs:
           files: |
             archive.tar.gz
             index.json
-            varsion.json
+            version.json

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get latest release info
         run:
-          curl -fLO https://github.com/rivnakm/AutoEqPackages/releases/latest/download/version.json || true
+          curl -fLO https://github.com/timschneeb/AutoEqPackages/releases/latest/download/version.json || true
 
       - name: Run packaging script
         run: |

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -9,49 +9,55 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: write
     steps:
-      - name: "Prepare environment"
-        run: |
-          sudo apt update
-          sudo apt install git
-    
-      - name: "Checkout"
-        uses: actions/checkout@v2
-      
-      - name: "Checkout AutoEQ"    
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Checkout AutoEQ
+        uses: actions/checkout@v5
         with:
           repository: jaakkopasanen/AutoEq
           path: autoeq/
-          
-      - name: Set up python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-          
+
+      - name: Get latest release info
+        run:
+          curl -fLO https://github.com/rivnakm/AutoEqPackages/releases/latest/download/version.json || true
+
       - name: Run packaging script
         run: |
           cd autoeq
           python ../package.py
-          
+
       - name: Check file existence
-        id: check_files
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "autoeq/archive.tar.gz, autoeq/export/index.json, autoeq/export/version.json"
-        
+        run: |
+          test -e autoeq/archive.tar.gz
+          test -e autoeq/export/index.json
+          test -e autoeq/export/version.json
+
       - name: Collect exported data
-        if: steps.check_files.outputs.files_exists == 'true'
         run: |
           mv autoeq/archive.tar.gz .
           mv autoeq/export/index.json .
           mv autoeq/export/version.json .
           rm -rf autoeq
-          
-      - name: Publish changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        if: steps.check_files.outputs.files_exists == 'true'
+
+      - name: Create tag
+        id: create-tag
+        run: |
+          TAG="autoeq-$(date -uI)"
+          echo "tag-name=${TAG}" >> "${GITHUB_OUTPUT}"
+          git tag "${TAG}"
+          git push --tags
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
         with:
-          commit_message: Update archive
-          file_pattern: ./*.tar.gz ./*.json
+          tag_name: ${{ steps.create-tag.outputs.tag-name }}
+          files: |
+            archive.tar.gz
+            index.json
+            varsion.json

--- a/package.py
+++ b/package.py
@@ -23,7 +23,7 @@ def main():
             if json.load(file)[0]["commit"] == commit:
                 print("No new commits were pushed to the upstream repo. Archive is already up-to-date")
                 exit(0)
-        
+
     # Parse INDEX.md
     indices = []
     with open("results/INDEX.md") as file:
@@ -93,7 +93,7 @@ def main():
         "commit": subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip(),
         "commit_time": datetime.utcfromtimestamp(int(subprocess.check_output(['git', 'log', '-1', '--format=%at'], text=True).strip())).strftime('%Y/%m/%d %H:%M:%S'),
         "package_time": time.strftime('%Y/%m/%d %H:%M:%S'),
-        "package_url": "https://github.com/ThePBone/AutoEqPackages/raw/main/archive.tar.gz",
+        "package_url": "https://github.com/timschneeb/AutoEqPackages/releases/latest/download/archive.tar.gz",
         "type": ["GraphicEQ", "CSV"]
     }]
     with open('export/version.json', 'w') as outfile:


### PR DESCRIPTION
Hi I found your repo while setting up JDSP4Linux and noticed that it was a bit out of date. I originally forked it an ran the release action but noticed that the archive is over the non-LFS size limit so I updated the workflow to publish it to a github release instead.